### PR TITLE
Fix a build failure due to missing project/lib folder

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -31,7 +31,7 @@
 	
 	<!-- Cobertura -->
 	<path id="cobertura.classpath">
-		<fileset dir="${cobertura.libs.dir}">
+		<fileset dir="${cobertura.libs.dir}" erroronmissingdir="false">
 			<include name="*.jar"/>
 		</fileset>
 	</path>
@@ -40,16 +40,16 @@
 	
 	<!-- Classpath declaration -->
     <path id="project.classpath">
-        <fileset dir="${project.libs}">
+        <fileset dir="${project.libs}" erroronmissingdir="false">
             <include name="**/*.jar"/>
         </fileset>
     </path>
 
 	<path id="base.path">
-		<fileset dir="${project.libs}">
+		<fileset dir="${project.libs}" erroronmissingdir="false">
 			<include name="**/*.jar" />
 		</fileset>
-		<fileset dir="${custom.libs}">
+		<fileset dir="${custom.libs}" erroronmissingdir="false">
 			<include name="**/*.jar" />
 		</fileset>
 	</path>


### PR DESCRIPTION
The build used to fail due to missing jforum3/lib (which is used in the classpath path references in the build script). This commit fixes that issue by using Ant fileset's erroronmissingdir attribute to be set to false.

Note that this gets the build past this specific error but it fails later due to a lot of missing jars (like JPA, Hibernate and Spring).
